### PR TITLE
feat: add comment functionality to blogs with like and view tracking

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -158,19 +158,23 @@ model Article {
 }
 
 model Comment {
-  id        Int      @id @default(autoincrement())
-  content   String   @db.Text
-  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id        Int       @id @default(autoincrement())
+  content   String    @db.Text
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId    Int
-  post      Post?    @relation(fields: [postId], references: [id], onDelete: Cascade)
+  post      Post?     @relation(fields: [postId], references: [id], onDelete: Cascade)
   postId    Int?
-  article   Article? @relation(fields: [articleId], references: [id], onDelete: Cascade)
+  article   Article?  @relation(fields: [articleId], references: [id], onDelete: Cascade)
   articleId Int?
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  parent    Comment?  @relation("CommentReplies", fields: [parentId], references: [id], onDelete: Cascade)
+  parentId  Int?
+  replies   Comment[] @relation("CommentReplies")
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
 
   @@index([postId])
   @@index([articleId])
+  @@index([parentId])
 }
 
 model Like {

--- a/src/modules/blogs/blogs.controller.ts
+++ b/src/modules/blogs/blogs.controller.ts
@@ -18,6 +18,7 @@ import { CreateBlogDto } from './dto/create-blog.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 import { FindAllBlogDto } from './dto/find-all-blogs';
 import { UpdateBlogDto } from './dto/update-blog.dto';
+import { CreateCommentDto } from './dto/create-comment.dto';
 
 @Controller('/v1/blogs')
 export class BlogsController {
@@ -93,5 +94,42 @@ export class BlogsController {
     @Req() req: JwtRequest,
   ) {
     return this.blogsService.rejectBlog(id, req.user);
+  }
+
+  @Post(':id/like')
+  @UseGuards(JwtAuthGuard)
+  async toggleLike(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: JwtRequest,
+  ) {
+    return this.blogsService.toggleLike(id, req.user.userId);
+  }
+
+  @Post(':id/comments')
+  @UseGuards(JwtAuthGuard)
+  async createComment(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: JwtRequest,
+    @Body() createCommentDto: CreateCommentDto,
+  ) {
+    return this.blogsService.createComment(
+      id,
+      req.user.userId,
+      createCommentDto,
+    );
+  }
+
+  @Delete('comments/:id')
+  @UseGuards(JwtAuthGuard)
+  async deleteComment(
+    @Param('id', ParseIntPipe) id: number,
+    @Req() req: JwtRequest,
+  ) {
+    return this.blogsService.deleteComment(id, req.user.userId);
+  }
+
+  @Post(':id/view')
+  async incrementView(@Param('id', ParseIntPipe) id: number) {
+    return this.blogsService.incrementView(id);
   }
 }

--- a/src/modules/blogs/dto/create-comment.dto.ts
+++ b/src/modules/blogs/dto/create-comment.dto.ts
@@ -1,0 +1,10 @@
+import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+
+export class CreateCommentDto {
+  @IsNotEmpty()
+  @IsString()
+  content: string;
+
+  @IsOptional()
+  parentId?: number;
+}


### PR DESCRIPTION
- Introduced CreateCommentDto for comment creation.
- Implemented createComment and deleteComment methods in BlogsService.
- Added toggleLike method to manage likes on blogs.
- Enhanced BlogsController with endpoints for liking, commenting, and viewing blogs.
- Updated Prisma schema to support comment replies and parent-child relationships.